### PR TITLE
[Break Change]Reduce packed result classes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,9 +1,13 @@
+# -*- coding: utf-8 -*-
 #!/usr/bin/env python
 import os, shutil
 from SCons.Variables import Variables
 from SCons.Script import SConscript
 from SCons.Environment import Environment
 from SCons.Tool import Tool
+
+import os
+os.system("chcp 65001")
 
 env :Environment = SConscript("godot-cpp/SConstruct")
 

--- a/gd_eos/include/core/eos_data_class.h
+++ b/gd_eos/include/core/eos_data_class.h
@@ -5,80 +5,29 @@
 #include <godot_cpp/classes/ref_counted.hpp>
 
 #ifdef DEBUG_ENABLED
-#include "godot_cpp/templates/hash_map.hpp"
 #include "godot_cpp/templates/local_vector.hpp"
 #endif // DEBUG_ENABLED
 
 namespace godot::eos {
 
-class EOSDataClassOptions : public RefCounted {
-    GDCLASS(EOSDataClassOptions, RefCounted)
-
-    bool sort_keys = true;
-    bool include_null_in_dict = true;
-    bool include_null_in_print = true;
-    bool print_newline = true;
-    PackedStringArray print_exclude;
-
-public:
-    _DECLARE_SETGET_BOOL(sort_keys)
-    _DECLARE_SETGET_BOOL(include_null_in_dict)
-    _DECLARE_SETGET_BOOL(include_null_in_print)
-    _DECLARE_SETGET_BOOL(print_newline)
-    _DECLARE_SETGET(print_exclude)
-
-protected:
-    static void _bind_methods() {
-        _BIND_BEGIN(EOSDataClassOptions)
-        _BIND_PROP_BOOL(sort_keys);
-        _BIND_PROP_BOOL(include_null_in_dict);
-        _BIND_PROP_BOOL(include_null_in_print);
-        _BIND_PROP_BOOL(print_newline);
-        _BIND_PROP(print_exclude);
-        _BIND_END()
-    }
-};
-
 class EOSDataClass : public RefCounted {
     GDCLASS(EOSDataClass, RefCounted)
-
-    Ref<EOSDataClassOptions> print_options;
-
-    static Ref<EOSDataClassOptions> get_defailt_options() {
-        static Ref<EOSDataClassOptions> ret = memnew(EOSDataClassOptions);
-        return ret;
-    }
 
     static bool is_valid_prop(const Dictionary &p_prop) {
         return ((int64_t)(p_prop["usage"]) & PROPERTY_USAGE_STORAGE) != 0 &&
                 ((String)(p_prop["name"])) != "print_options" && p_prop["name"] != "script";
     }
 
-    bool is_not_exclude_prop(const StringName &p_name, const Ref<EOSDataClassOptions> &p_print_options) const {
-        return !p_print_options->get_print_exclude().has(p_name);
-    }
-
-    static String stringify(const Variant &p_val, bool p_new_line = false, int p_indent = 0);
-
 protected:
     static void _bind_methods();
 
-    Ref<EOSDataClassOptions> _get_print_options() const {
-        if (print_options.is_valid()) {
-            return print_options;
-        }
-        return get_defailt_options();
-    }
-
-    TypedArray<StringName> get_props(bool p_sort) const;
+    LocalVector<StringName> get_props() const;
 
 public:
     String _to_string() const;
 
 public:
     Dictionary to_dict() const;
-
-    _DECLARE_SETGET_TYPED(print_options, Ref<EOSDataClassOptions>)
 };
 
 }; //namespace godot::eos

--- a/gd_eos/include/core/eos_packed_result.h
+++ b/gd_eos/include/core/eos_packed_result.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <godot_cpp/classes/ref_counted.hpp>
+#include "eos_data_class.h"
 
 namespace godot::eos {
-class EOSPackedResult : public RefCounted {
-    GDCLASS(EOSPackedResult, RefCounted)
+class EOSPackedResult : public EOSDataClass {
+    GDCLASS(EOSPackedResult, EOSDataClass)
 protected:
     static void _bind_methods() {}
 };

--- a/gd_eos/include/core/utils.h
+++ b/gd_eos/include/core/utils.h
@@ -913,7 +913,7 @@ public:                                                                         
 private:
 
 #define _CODE_SNIPPET_DEFINE_LAST_RESULT_CODE() \
-    static EOS_EResult EOS::last_result_code = EOS_EResult::EOS_Success;
+    EOS_EResult EOS::last_result_code = EOS_EResult::EOS_Success;
 
 // EOS VERSION
 #define _EOS_GET_VERSION() \

--- a/gd_eos/include/core/utils.h
+++ b/gd_eos/include/core/utils.h
@@ -902,15 +902,29 @@ auto _to_godot_val_from_union(EOSUnion &p_eos_union, EOSUnionTypeEnum p_type) {
         return return_action;                                                                                                             \
     }
 
+#define _CODE_SNIPPET_DECLARE_LAST_RESULT_CODE()                                                       \
+private:                                                                                               \
+    static EOS_EResult last_result_code;                                                               \
+                                                                                                       \
+public:                                                                                                \
+    static void _set_last_result_code(EOS_EResult p_result_code) { last_result_code = p_result_code; } \
+    static EOS_EResult get_last_result_code() { return last_result_code; }                             \
+                                                                                                       \
+private:
+
+#define _CODE_SNIPPET_DEFINE_LAST_RESULT_CODE() \
+    static EOS_EResult EOS::last_result_code = EOS_EResult::EOS_Success;
+
 // EOS VERSION
 #define _EOS_GET_VERSION() \
     static String get_eos_version() { return EOS_GetVersion(); }
 
-#define _EOS_BING_VERSION_CONSTANTS() \
-    BIND_CONSTANT(EOS_MAJOR_VERSION)  \
-    BIND_CONSTANT(EOS_MINOR_VERSION)  \
-    BIND_CONSTANT(EOS_PATCH_VERSION)  \
-    ClassDB::bind_static_method(get_class_static(), D_METHOD("get_eos_version"), &EOS::get_eos_version);
+#define _EOS_BING_VERSION_CONSTANTS()                                                                    \
+    BIND_CONSTANT(EOS_MAJOR_VERSION)                                                                     \
+    BIND_CONSTANT(EOS_MINOR_VERSION)                                                                     \
+    BIND_CONSTANT(EOS_PATCH_VERSION)                                                                     \
+    ClassDB::bind_static_method(get_class_static(), D_METHOD("get_eos_version"), &EOS::get_eos_version); \
+    ClassDB::bind_static_method(get_class_static(), D_METHOD("get_last_result_code"), &EOS::get_last_result_code);
 
 // Handles
 #define _EOS_HANDLE_IS_EQUAL(m_handle_identifier, m_other_identifier) \

--- a/gd_eos/src/core/eos_data_class.cpp
+++ b/gd_eos/src/core/eos_data_class.cpp
@@ -2,132 +2,73 @@
 
 namespace godot::eos {
 
-_DEFINE_SETGET_BOOL(EOSDataClassOptions, sort_keys)
-_DEFINE_SETGET_BOOL(EOSDataClassOptions, include_null_in_dict)
-_DEFINE_SETGET_BOOL(EOSDataClassOptions, include_null_in_print)
-_DEFINE_SETGET_BOOL(EOSDataClassOptions, print_newline)
-_DEFINE_SETGET(EOSDataClassOptions, print_exclude)
-
-// ==== EOSDataClass ====
-_DEFINE_SETGET_TYPED(EOSDataClass, print_options, Ref<EOSDataClassOptions>);
-
 void EOSDataClass::_bind_methods() {
     ClassDB::bind_method(D_METHOD("to_dict"), &EOSDataClass::to_dict);
-
-    ClassDB::bind_method(D_METHOD("get_print_options"), &EOSDataClass::get_print_options);
-    ClassDB::bind_method(D_METHOD("set_print_options", "print_options"), &EOSDataClass::set_print_options);
-    ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "print_options", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE, EOSDataClassOptions::get_class_static()), "set_print_options", "get_print_options");
 }
 
-TypedArray<StringName> EOSDataClass::get_props(bool p_sort) const {
-    TypedArray<StringName> ret;
-
+LocalVector<StringName> EOSDataClass::get_props() const {
     auto props = get_property_list().filter(callable_mp_static(is_valid_prop));
 
+    LocalVector<StringName> ret;
+    ret.reserve(props.size());
     for (int i = 0; i < props.size(); ++i) {
-        ret.append(props[i].operator Dictionary()["name"]);
+        ret.push_back(props[i].operator Dictionary()["name"]);
     }
 
-    if (p_sort) {
-        ret.sort();
-    }
-
-    return ret;
-}
-
-String EOSDataClass::stringify(const Variant &p_val, bool p_new_line, int p_indent) {
-    String ret;
-
-    String tab = "";
-    String new_line = "";
-    String join_str = ", ";
-
-    if (p_new_line) {
-        tab = "\t";
-        new_line = "\n";
-        join_str = ",\n";
-    }
-
-    if (auto dc = Object::cast_to<EOSDataClass>(p_val)) {
-        ret = dc->_to_string();
-    } else {
-        if (p_val.get_type() == Variant::DICTIONARY) {
-            Dictionary dict = p_val.operator Dictionary();
-
-            auto keys = dict.keys();
-            auto values = dict.values();
-
-            PackedStringArray pairs;
-
-            for (auto i = 0; i < keys.size(); ++i) {
-                auto key = keys[i];
-                auto val = values[i];
-                pairs.push_back(vformat(tab + "%s: %s", stringify(key, p_new_line, p_indent + 1), stringify(val, p_new_line, p_indent + 1)));
-            }
-
-            ret = "{" + new_line;
-            ret += join_str.join(pairs);
-            ret += "}" + new_line;
-        } else if (p_val.get_type() == Variant::ARRAY) {
-            Array arr = p_val;
-
-            PackedStringArray vals;
-            for (auto i = 0; i < arr.size(); ++i) {
-                vals.push_back(tab + stringify(arr[i], p_new_line, p_indent + 1));
-            }
-
-            ret = "[" + new_line;
-            ret += join_str.join(vals);
-            ret += "]" + new_line;
-        } else {
-            ret = p_val.stringify();
-        }
-    }
-
-    if (p_new_line) {
-        ret.indent(tab.repeat(p_indent));
-    }
     return ret;
 }
 
 String EOSDataClass::_to_string() const {
-    auto options = _get_print_options();
-    auto prop_names = get_props(options->is_sort_keys()).filter(callable_mp(this, &EOSDataClass::is_not_exclude_prop).bind(options));
-
-    PackedStringArray props;
-    for (int i = 0; i < prop_names.size(); ++i) {
-        auto val = get(prop_names[i]);
-        if (val.get_type() != Variant::NIL || options->is_include_null_in_print()) {
-            props.append(vformat(options->is_print_newline() ? "\n\t%s = %s" : "%s = %s", prop_names[i], stringify(val, options->is_print_newline())));
-        }
-    }
-
-    String line_end = "";
-    String new_line = "";
-    String new_line_end = "";
-    String join_str = ", ";
-
-    if (options->is_print_newline()) {
-        line_end = "\n";
-        new_line = "\n\t";
-        new_line_end = ",\n";
-        join_str = ",";
-    }
-
-    return vformat("%s (%s%s)", get_class(), join_str.join(props), new_line_end);
+    return vformat("<%s#%d>", get_class_static(), get_instance_id());
 }
 
 Dictionary EOSDataClass::to_dict() const {
-    auto options = _get_print_options();
-    auto prop_names = get_props(options->is_sort_keys());
+    auto prop_names = get_props();
 
     Dictionary ret;
     for (int i = 0; i < prop_names.size(); ++i) {
         String prop_name = prop_names[i];
         auto val = get(prop_name);
-        if (val.get_type() != Variant::NIL || options->is_include_null_in_dict()) {
-            ret[prop_name] = val;
+        if (auto dc = cast_to<EOSDataClass>(val)) {
+            val = dc->to_dict();
+        } else if (val.get_type() == Variant::DICTIONARY) {
+            Dictionary dict = val.operator Dictionary();
+            Dictionary new_dict;
+
+            auto keys = dict.keys();
+            auto values = dict.values();
+
+            for (auto i = 0; i < keys.size(); ++i) {
+                auto key = keys[i];
+                auto val = values[i];
+
+                if (auto dc = cast_to<EOSDataClass>(key)) {
+                    key = dc->to_dict();
+                }
+                if (auto dc = cast_to<EOSDataClass>(val)) {
+                    val = dc->to_dict();
+                }
+
+                new_dict[key] = val;
+            }
+
+            val = new_dict;
+        } else if (val.get_type() == Variant::ARRAY) {
+            Array arr = val;
+            Array new_arr;
+            for (auto i = 0; i < arr.size(); ++i) {
+                Variant v = arr[i];
+                if (auto dc = cast_to<EOSDataClass>(v)) {
+                    new_arr.push_back(dc->to_dict());
+                } else {
+                    new_arr.push_back(v);
+                }
+            }
+
+            val = new_arr;
         }
+
+        ret[prop_name] = val;
     }
 
     return ret;

--- a/gd_eos/src/register_types.cpp
+++ b/gd_eos/src/register_types.cpp
@@ -29,7 +29,6 @@ void initialize_gdeos_module(ModuleInitializationLevel p_level) {
         return;
     }
 
-    GDREGISTER_ABSTRACT_CLASS(godot::eos::EOSDataClassOptions);
     GDREGISTER_ABSTRACT_CLASS(godot::eos::EOSDataClass);
     GDREGISTER_ABSTRACT_CLASS(godot::eos::EOSPackedResult);
 

--- a/tools/binding_generator.py
+++ b/tools/binding_generator.py
@@ -1070,7 +1070,7 @@ def _gen_handle(
         ret.append(f"\t{klass}();")
     # Destructor
     if len(release_method) or len(remove_notifies_lines):  # and not is_base_handle_type:
-        ret.append(f"\t~{klass}();")
+        ret.append(f"\tvirtual ~{klass}() override;")
     # Handle setget
     if not is_base_handle_type:
         ret.append(f"\tvoid set_handle({handle_name} p_handle);")

--- a/tools/binding_generator.py
+++ b/tools/binding_generator.py
@@ -439,8 +439,8 @@ def gen_files(file_base_name: str, infos: dict):
         if has_packed_result:
             additional_include_lines.append(f'#include <packed_results/{file_base_name + ".packed_results.h"}>')
         else:
-            additional_include_lines.append(f'#include <{file_base_name}_types.h>') # 句柄类型
-            additional_include_lines.append(f'#include <core/utils.h>') # is_equal() 使用其中的 _EOS_HANDLE_IS_EQUAL 宏
+            additional_include_lines.append(f"#include <{file_base_name}_types.h>")  # 句柄类型
+            additional_include_lines.append(f"#include <core/utils.h>")  # is_equal() 使用其中的 _EOS_HANDLE_IS_EQUAL 宏
 
         if assume_only_one_local_user and file_base_name == "eos_common":
             # 假定只有一个用户时定义 EOS_ASSUME_ONLY_ONE_USER 宏
@@ -3117,7 +3117,7 @@ def is_deprecated_field(field: str) -> bool:
     )
 
 
-def remap_type(type: str, field: str = "", forward_declare :bool = False) -> str:
+def remap_type(type: str, field: str = "", forward_declare: bool = False) -> str:
     if _is_enum_type(type):
         # 枚举类型原样返回
         return type
@@ -4231,6 +4231,8 @@ def _gen_struct_v2(
         lines.append(f"\tvoid set_to_eos({struct_type} &p_origin);")
     if additional_methods_requirements["to"]:
         lines.append(f"\t{struct_type} &to_eos() {{set_to_eos(m_eos_data); return m_eos_data;}}")
+    lines.append("")
+    lines.append(f"\tString _to_string() const;")
     lines.append("protected:")
     lines.append("\tstatic void _bind_methods();")
     lines.append("};")
@@ -4502,6 +4504,9 @@ def _gen_struct_v2(
         for line in optional_cpp_lines:
             r_structs_cpp.insert(insert_idx, line)
 
+    r_structs_cpp.append("")
+    r_structs_cpp.append(f'String {typename}::_to_string() const {{ return vformat("<{typename}#%d>", get_instance_id()); }}')
+    r_structs_cpp.append("")
     # doc
     _insert_doc_class_brief(typename, struct_info["doc"])
     _insert_doc_class_description(typename)
@@ -4557,11 +4562,11 @@ def __make_callback_doc(callback_type: str) -> list[str]:
 
         decayed_type = _decay_eos_type(type)
         if not _is_expanded_struct(decayed_type):
-            doc:list[str] = structs[decayed_type]['doc']
-            snake_name :str = to_snake_case(name)
+            doc: list[str] = structs[decayed_type]["doc"]
+            snake_name: str = to_snake_case(name)
 
             if len(doc) == 1:
-                l = doc[0].lstrip('\t')
+                l = doc[0].lstrip("\t")
                 ret.append(f"{snake_name} ({decayed_type}): {l}")
             else:
                 ret.append(f"{snake_name} ({decayed_type}):\n")
@@ -4577,21 +4582,21 @@ def __make_callback_doc(callback_type: str) -> list[str]:
                     # 跳过其中Godot不需要的字段
                     continue
                 info = arg_fields[f]
-                doc :list[str] = info["doc"]
+                doc: list[str] = info["doc"]
                 f_type = _decay_eos_type(info["type"])
-                f_snake_name :str = to_snake_case(f)
+                f_snake_name: str = to_snake_case(f)
 
                 if f_type.startswith("void") and f == "ClientData":
-                    continue # 跳过这个特殊字段
+                    continue  # 跳过这个特殊字段
 
                 if len(doc) == 1:
-                    l = doc[0].lstrip('\t')
+                    l = doc[0].lstrip("\t")
                     ret.append(f"{f_snake_name} ({f_type}): {l}")
                 else:
                     ret.append(f"{f_snake_name} ({f_type}):\n")
                     for l in info["doc"]:
                         ret.append(f"\t{l}\n")
-    ret.append("") # 插入空字符用于标记改参数必须换行
+    ret.append("")  # 插入空字符用于标记改参数必须换行
     return ret
 
 

--- a/tools/binding_generator.py
+++ b/tools/binding_generator.py
@@ -966,6 +966,7 @@ def _gen_handle(
 
     if klass == "EOS":
         method_define_lines.append("\t_EOS_GET_VERSION()")
+        method_define_lines.append("\t_CODE_SNIPPET_DECLARE_LAST_RESULT_CODE()")
         method_define_lines.append("")
 
     # String Constants
@@ -1145,6 +1146,9 @@ def _gen_handle(
         r_cpp_lines.append(f"\t_CODE_SNIPPET_BINE_GET_LOCAL_ID({klass});")
 
     r_cpp_lines.append(f"}}")
+
+    if klass == "EOS":
+        r_cpp_lines.append("\t_CODE_SNIPPET_DEFINE_LAST_RESULT_CODE()")
 
     # 注册宏
     r_register_lines.append(f"\tGDREGISTER_ABSTRACT_CLASS(godot::eos::{klass})\\")
@@ -2972,14 +2976,18 @@ def _convert_enum_value(ori: str) -> str:
 
 
 def _is_need_skip_struct(struct_type: str) -> bool:
-    return struct_type in [
-        "EOS_AntiCheatCommon_Quat",
-        "EOS_AntiCheatCommon_Vec3f",
-        # 直接使用字符串代替
-        "EOS_P2P_SocketId",
-        # 未使用
-        "EOS_UI_Rect",
-    ] or "_Reserved" in struct_type # 保留的API, 不能被用户调用
+    return (
+        struct_type
+        in [
+            "EOS_AntiCheatCommon_Quat",
+            "EOS_AntiCheatCommon_Vec3f",
+            # 直接使用字符串代替
+            "EOS_P2P_SocketId",
+            # 未使用
+            "EOS_UI_Rect",
+        ]
+        or "_Reserved" in struct_type
+    )  # 保留的API, 不能被用户调用
 
 
 def _is_need_skip_callback(callback_type: str) -> bool:
@@ -2988,26 +2996,30 @@ def _is_need_skip_callback(callback_type: str) -> bool:
 
 def _is_need_skip_method(method_name: str) -> bool:
     # TODO: Create , Release, GetInterface 均不需要
-    return method_name in [
-        "EOS_ByteArray_ToString",  # Godot 压根就不需要
-        # 废弃 DEPRECATED!
-        "EOS_Achievements_CopyAchievementDefinitionByIndex",
-        "EOS_Achievements_CopyAchievementDefinitionByAchievementId",
-        "EOS_Achievements_GetUnlockedAchievementCount",
-        "EOS_Achievements_CopyUnlockedAchievementByIndex",
-        "EOS_Achievements_CopyUnlockedAchievementByAchievementId",
-        "EOS_Achievements_AddNotifyAchievementsUnlocked",
-        "EOS_RTCAudio_RegisterPlatformAudioUser",
-        "EOS_RTCAudio_UnregisterPlatformAudioUser",
-        "EOS_RTCAudio_GetAudioInputDevicesCount",
-        "EOS_RTCAudio_GetAudioInputDeviceByIndex",
-        "EOS_RTCAudio_GetAudioOutputDevicesCount",
-        "EOS_RTCAudio_GetAudioOutputDeviceByIndex",
-        "EOS_RTCAudio_SetAudioInputSettings",
-        "EOS_RTCAudio_SetAudioOutputSettings",
-        # 废弃 NOT: This api is deprecated.
-        "EOS_AntiCheatClient_PollStatus",
-    ] or "_Reserved" in method_name # 保留的API, 不能被用户调用
+    return (
+        method_name
+        in [
+            "EOS_ByteArray_ToString",  # Godot 压根就不需要
+            # 废弃 DEPRECATED!
+            "EOS_Achievements_CopyAchievementDefinitionByIndex",
+            "EOS_Achievements_CopyAchievementDefinitionByAchievementId",
+            "EOS_Achievements_GetUnlockedAchievementCount",
+            "EOS_Achievements_CopyUnlockedAchievementByIndex",
+            "EOS_Achievements_CopyUnlockedAchievementByAchievementId",
+            "EOS_Achievements_AddNotifyAchievementsUnlocked",
+            "EOS_RTCAudio_RegisterPlatformAudioUser",
+            "EOS_RTCAudio_UnregisterPlatformAudioUser",
+            "EOS_RTCAudio_GetAudioInputDevicesCount",
+            "EOS_RTCAudio_GetAudioInputDeviceByIndex",
+            "EOS_RTCAudio_GetAudioOutputDevicesCount",
+            "EOS_RTCAudio_GetAudioOutputDeviceByIndex",
+            "EOS_RTCAudio_SetAudioInputSettings",
+            "EOS_RTCAudio_SetAudioOutputSettings",
+            # 废弃 NOT: This api is deprecated.
+            "EOS_AntiCheatClient_PollStatus",
+        ]
+        or "_Reserved" in method_name
+    )  # 保留的API, 不能被用户调用
 
 
 def _is_need_skip_enum_type(ori_enum_type: str) -> bool:
@@ -3404,9 +3416,13 @@ def _is_deprecated_constant(name: str) -> bool:
 
 
 def _is_need_skip_constant(name: str) -> bool:
-    return name in [
-        "EOS_ANTICHEATCLIENT_PEER_SELF",  # 指针，非常量
-    ] or "_RESERVED" in name # 被保留的常量，不能被用户调用
+    return (
+        name
+        in [
+            "EOS_ANTICHEATCLIENT_PEER_SELF",  # 指针，非常量
+        ]
+        or "_RESERVED" in name
+    )  # 被保留的常量，不能被用户调用
 
 
 def _is_string_constant(val: str) -> bool:
@@ -4088,7 +4104,7 @@ def _gen_struct_v2(
             setget_define_lines.append(f"_DEFINE_SETGET({typename}, {snake_field_name})")
             member_lines.append(f"\t{remapped_type} {snake_field_name}{{ -1.0 }};")
         elif _is_pure_handle_type(decayed_type):
-            bind_lines.append(f'\t_BIND_PROP({snake_field_name})')
+            bind_lines.append(f"\t_BIND_PROP({snake_field_name})")
             setget_declare_lines.append(f"\t_DECLARE_SETGET({snake_field_name})")
             setget_define_lines.append(f"_DEFINE_SETGET({typename}, {snake_field_name})")
             member_lines.append(f"\t{remapped_type} {snake_field_name}{{ 0 }};")


### PR DESCRIPTION
1. Reduce generating packed result classes: Instead of returning a packed result which contain  a `EOS_Result` and a object type, return the object directly, and provide `EOS.get_last_result_code()` for checking the error if return `null`.
2. Remove `EOSDataClassOptions`.
3. Optimize generating document:
- Remove `@param ClientData`.
- Remove empty line.
- Convert arguments' name to snake_case.